### PR TITLE
Add saved filters and last activity tracking for Prediction page

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ db.users.updateOne({ username: "your_username" }, { $set: { role: "admin" } })
 ```
 
 ---
+###  Backend Architecture Diagram
+
+![FoodLens Backend Architecture](./assets/flowChart.png)
+
+---
 
 ## License & Data Source
 

--- a/controllers/homeController.js
+++ b/controllers/homeController.js
@@ -1,0 +1,15 @@
+const User = require("../models/User");
+
+async function showHomePage(req, res) {
+  try {
+    const user = await User.findById(req.user._id);
+    const toast = req.session.toastMessage || null;
+    delete req.session.toastMessage;
+    res.render("home", { user, welcomeMessage: toast });
+  } catch (err) {
+    console.error("Error loading home:", err);
+    res.redirect("/login");
+  }
+}
+
+module.exports = { showHomePage };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,68 @@
+const User = require("../models/User");
+
+async function saveChartFilters(req, res) {
+  const { chart, filters } = req.body;
+
+  if (!chart || !filters) {
+    console.log("Missing chart or filters in request");
+    return res.status(400).json({ message: "Chart and filters are required." });
+  }
+
+  // Safely resolve userId
+  const userId = req.user?._id || req.session?.passport?.user;
+  console.log("Resolved userId:", userId);
+
+  try {
+    const user = await User.findById(userId);
+
+    if (!user) {
+      console.log("User not found:", userId);
+      return res.status(404).json({ message: "User not found." });
+    }
+
+    console.log("Before:", user.lastFilters);
+    user.lastFilters[chart] = filters;
+    user.markModified('lastFilters');
+    user.lastActivity = new Date();
+
+    await user.save();
+    console.log("Saved filters for:", user.username);
+    console.log("After save:", user.lastFilters);
+
+    res.status(200).json({ message: "Filters saved." });
+  } catch (err) {
+    console.error("Error saving filters:", err);
+    res.status(500).json({ message: "Server error." });
+  }
+}
+
+async function getChartFilters(req, res) {
+  const { chart } = req.query;
+
+  if (!chart) {
+    return res.status(400).json({ message: "Chart query param is required." });
+  }
+
+  // Safely resolve userId
+  const userId = req.user?._id || req.session?.passport?.user;
+
+  try {
+    const user = await User.findById(userId);
+
+    if (!user) {
+      console.log("User not found during getChartFilters:", userId);
+      return res.status(404).json({ message: "User not found." });
+    }
+
+    const filters = user.lastFilters?.[chart] || {};
+    res.status(200).json({ filters });
+  } catch (err) {
+    console.error("Error getting filters:", err);
+    res.status(500).json({ message: "Server error." });
+  }
+}
+
+module.exports = {
+  saveChartFilters,
+  getChartFilters,
+};

--- a/models/User.js
+++ b/models/User.js
@@ -16,6 +16,14 @@ const userSchema = new mongoose.Schema({
     type: String,
     enum: ["user", "admin"],
     default: "user"
+  },
+  lastFilters: {
+    type: Object,
+    default: {}
+  },
+  lastActivity: {
+    type: Date,
+    default: null
   }
 });
 

--- a/public/script_predict.js
+++ b/public/script_predict.js
@@ -1,99 +1,203 @@
 document.addEventListener("DOMContentLoaded", function () {
-    M.FormSelect.init(document.querySelectorAll("select"));
-    const categorySelect = document.getElementById("categorySelect");
-    const groupSelect = document.getElementById("groupSelect");
-    const ctx = document.getElementById("predictChart").getContext("2d");
-  
-    let chart;
-  
-    // Load group values when category changes
-    categorySelect.addEventListener("change", async () => {
-      const category = categorySelect.value;
-      groupSelect.innerHTML = '<option value="" disabled selected>Select Group</option>';
+  const categorySelect = document.getElementById("categorySelect");
+  const groupSelect = document.getElementById("groupSelect");
+  const ctx = document.getElementById("predictChart").getContext("2d");
+
+  let chart;
+  let isInitialLoad = true;
+
+  M.FormSelect.init(document.querySelectorAll("select"));
+
+  applySavedFilters();
+
+  categorySelect.addEventListener("change", async () => {
+    groupSelect.innerHTML = '<option value="" disabled selected>Select Group</option>';
+    const inst = M.FormSelect.getInstance(groupSelect);
+    if (inst) inst.destroy();
+    M.FormSelect.init(groupSelect);
+
+    if (chart) {
+      chart.destroy();
+      chart = null;
+    }
+
+    await loadGroups(categorySelect.value);
+  });
+
+  groupSelect.addEventListener("change", renderChart);
+
+  // Place reset listener AFTER categorySelect, groupSelect, and chart are defined
+  document.getElementById("resetButton").addEventListener("click", () => {
+    categorySelect.value = "";
+    groupSelect.innerHTML = '<option value="" disabled selected>Select Group</option>';
+
+    M.FormSelect.init(categorySelect);
+    const inst = M.FormSelect.getInstance(groupSelect);
+    if (inst) inst.destroy();
+    M.FormSelect.init(groupSelect);
+
+    if (chart) {
+      chart.destroy();
+      chart = null;
+    }
+
+    window.scrollTo(0, 0);
+  });
+
+  async function applySavedFilters() {
+    try {
+      const res = await fetch("/api/user/filters?chart=predict");
+      const { filters } = await res.json();
+
+      if (!filters?.category || !filters?.group) return;
+
+      categorySelect.value = filters.category;
+      M.FormSelect.init(categorySelect);
+
+      await loadGroups(filters.category, filters.group);
+
+      isInitialLoad = false;
+    } catch (err) {
+      console.error("Error applying saved filters:", err);
+    }
+  }
+
+  async function loadGroups(category, preselect = null) {
+    try {
       const res = await fetch(`/api/trends/values?category=${category}`);
       const { values } = await res.json();
-  
+
+      groupSelect.innerHTML = '<option value="" disabled selected>Select Group</option>';
       values.forEach(val => {
         const option = document.createElement("option");
         option.value = val;
         option.textContent = val;
+
+        if (isInitialLoad && preselect === val) {
+          option.selected = true;
+        }
+
         groupSelect.appendChild(option);
       });
-  
+
+      const inst = M.FormSelect.getInstance(groupSelect);
+      if (inst) inst.destroy();
       M.FormSelect.init(groupSelect);
+
+      if (isInitialLoad && preselect) {
+        renderChart();
+      }
+    } catch (err) {
+      console.error("Failed to load group values:", err);
+    }
+  }
+
+function validateSelections() {
+  console.log("validateSelections called");
+
+  const category = categorySelect.value;
+  const group = groupSelect.value;
+
+  // If default selected OR no value
+  const categoryInvalid = !category || categorySelect.selectedIndex === 0;
+  const groupInvalid = !group || groupSelect.selectedIndex === 0;
+
+  if (categoryInvalid || groupInvalid) {
+    M.toast({
+      html: "Please select both a category and a group.",
+      classes: "rounded red lighten-1 white-text"
     });
-  
-    // Load chart when group is selected
-    groupSelect.addEventListener("change", renderChart);
-    categorySelect.addEventListener("change", renderChart);
-  
-    async function renderChart() {
-      const category = categorySelect.value;
-      const group = groupSelect.value;
-  
-      if (!category || !group) return;
-  
-      try {
-        const res = await fetch(`/api/predict?category=${category}&group=${group}`);
-        const { years, actual, predicted, splitIndex } = await res.json();
-  
-        if (chart) chart.destroy();
-  
-        chart = new Chart(ctx, {
-          type: "line",
-          data: {
-            labels: years,
-            datasets: [
-              {
-                label: "Actual",
-                data: actual,
-                borderColor: "#42a5f5",
-                borderWidth: 2,
-                pointRadius: 4,
-                fill: false,
-                tension: 0.3
-              },
-              {
-                label: "Predicted",
-                data: Array(splitIndex).fill(null).concat(predicted),
-                borderColor: "#ff8a65",
-                borderDash: [5, 5],
-                borderWidth: 2,
-                pointRadius: 4,
-                fill: false,
-                tension: 0.3
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: {
-                  boxWidth: 18,
-                  padding: 15,
-                  font: {
-                    size: 13
-                  }
-                }
-              },
-              tooltip: {
-                mode: "index",
-                intersect: false
+    return false;
+  }
+
+  return true;
+}
+
+  async function renderChart() {
+    if (!validateSelections()) return;
+
+    const category = categorySelect.value;
+    const group = groupSelect.value;
+
+    document.body.style.cursor = "wait";
+
+    try {
+      await fetch("/api/user/filters", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chart: "predict",
+          filters: { category, group }
+        })
+      });
+    } catch (err) {
+      console.error("Failed to save filters:", err);
+    }
+
+    try {
+      const res = await fetch(`/api/predict?category=${category}&group=${group}`);
+      const { years, actual, predicted, splitIndex } = await res.json();
+
+      if (chart) chart.destroy();
+
+      chart = new Chart(ctx, {
+        type: "line",
+        data: {
+          labels: years,
+          datasets: [
+            {
+              label: "Actual",
+              data: actual,
+              borderColor: "#42a5f5",
+              borderWidth: 2,
+              pointRadius: 4,
+              fill: false,
+              tension: 0.3
+            },
+            {
+              label: "Predicted",
+              data: Array(splitIndex).fill(null).concat(predicted),
+              borderColor: "#ff8a65",
+              borderDash: [5, 5],
+              borderWidth: 2,
+              pointRadius: 4,
+              fill: false,
+              tension: 0.3
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              position: "bottom",
+              labels: {
+                boxWidth: 18,
+                padding: 15,
+                font: { size: 13 }
               }
             },
-            scales: {
-              y: {
-                beginAtZero: true
-              }
+            tooltip: {
+              mode: "index",
+              intersect: false
+            }
+          },
+          scales: {
+            y: {
+              beginAtZero: true
             }
           }
-        });
-      } catch (err) {
-        console.error("Prediction chart error:", err);
-      }
+        }
+      });
+    } catch (err) {
+      console.error("Prediction chart error:", err);
+      M.toast({
+        html: "Failed to load chart.",
+        classes: "rounded red lighten-1 white-text"
+      });
+    } finally {
+      document.body.style.cursor = "default";
     }
-  });
-  
+  }
+});

--- a/routes/home.js
+++ b/routes/home.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const { ensureAuthenticated } = require("../middleware/auth");
+const { showHomePage } = require("../controllers/homeController");
+
+router.get("/", ensureAuthenticated, showHomePage);
+
+module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+const { ensureAuthenticated } = require("../middleware/auth");
+const {
+  saveChartFilters,
+  getChartFilters
+} = require("../controllers/userController");
+
+router.post("/filters", ensureAuthenticated, saveChartFilters);
+router.get("/filters", ensureAuthenticated, getChartFilters);
+
+module.exports = router;

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -26,11 +26,39 @@
         width: 100%;
         max-width: 300px;
       }
+      .activity-card {
+        margin-bottom: 2rem;
+        padding: 1rem;
+        border-radius: 8px;
+        background-color: #e3f2fd;
+        width: 100%;
+        max-width: 400px;
+        text-align: center;
+        font-size: 15px;
+      }
     </style>
   </head>
 
-<body data-welcome="<%= welcomeMessage || '' %>">
+  <body data-welcome="<%= welcomeMessage || '' %>">
     <h4>Welcome to FoodLens, <%= user.username %>!</h4>
+
+  <% if (user.lastFilters?.predict?.category && user.lastFilters.predict.group && user.lastActivity) { %>
+    <!-- <p><%= JSON.stringify(user.lastFilters) %></p>
+    <p><%= user.lastActivity %></p> -->
+
+    <div class="activity-card z-depth-1">
+      <strong>Last Activity:</strong><br />
+      You last viewed <em>Predict</em> with
+      <strong><%= user.lastFilters.predict.category %></strong> →
+      "<%= user.lastFilters.predict.group %>"
+      on <%= new Date(user.lastActivity).toLocaleString() %>.
+    </div>
+  <% } else { %>
+    <div class="activity-card z-depth-1">
+      No recent activity yet. Explore the dashboard to get started!
+    </div>
+  <% } %>
+
 
     <div class="nav-btns">
       <a href="/type" class="btn waves-effect">Food Insecurity Types</a>
@@ -50,8 +78,6 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script src="/script_home.js"></script>
-
     <script src="/socket.io/socket.io.js"></script>
-
   </body>
 </html>

--- a/views/predict.ejs
+++ b/views/predict.ejs
@@ -43,127 +43,14 @@
     <canvas id="predictChart"></canvas>
   </div>
 
-    <!-- Back Button -->
+  <!-- Reset and back Button -->
   <div class="center-align" style="margin-top: 2rem;">
-    <a href="/" class="btn blue">Back to Home</a>
+  <a href="/" class="btn blue">Back to Home</a>
+  <button id="resetButton" class="btn orange darken-1" style="margin-left: 1rem;">Reset</button>
   </div>
 
-  
+  <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      M.FormSelect.init(document.querySelectorAll("select"));
-      const categorySelect = document.getElementById("categorySelect");
-      const groupSelect = document.getElementById("groupSelect");
-      const ctx = document.getElementById("predictChart").getContext("2d");
-
-      let chart;
-
-      categorySelect.addEventListener("change", async () => {
-        const category = categorySelect.value;
-        groupSelect.innerHTML = '<option value="" disabled selected>Select Group</option>';
-        const res = await fetch(`/api/trends/values?category=${category}`);
-        const { values } = await res.json();
-
-        values.forEach(val => {
-          const option = document.createElement("option");
-          option.value = val;
-          option.textContent = val;
-          groupSelect.appendChild(option);
-        });
-
-        M.FormSelect.init(groupSelect);
-        clearChart();
-      });
-
-      groupSelect.addEventListener("change", renderChart);
-      categorySelect.addEventListener("change", renderChart);
-
-      function clearChart() {
-        if (chart) {
-          chart.destroy();
-          chart = null;
-        }
-      }
-
-      async function renderChart() {
-        const category = categorySelect.value;
-        const group = groupSelect.value;
-
-        if (!category || !group) {
-          clearChart();
-          M.toast({
-            html: "Please select both a category and a group.",
-            classes: "rounded red lighten-1 white-text",
-            displayLength: 2000
-          });
-          return;
-        }
-
-        try {
-          const res = await fetch(`/api/predict?category=${category}&group=${group}`);
-          const { years, actual, predicted, splitIndex } = await res.json();
-
-          clearChart();
-
-          chart = new Chart(ctx, {
-            type: "line",
-            data: {
-              labels: years,
-              datasets: [
-                {
-                  label: "Actual",
-                  data: actual,
-                  borderColor: "#42a5f5",
-                  borderWidth: 2,
-                  pointRadius: 4,
-                  fill: false,
-                  tension: 0.3
-                },
-                {
-                  label: "Predicted",
-                  data: Array(splitIndex).fill(null).concat(predicted),
-                  borderColor: "#ff8a65",
-                  borderDash: [5, 5],
-                  borderWidth: 2,
-                  pointRadius: 4,
-                  fill: false,
-                  tension: 0.3
-                }
-              ]
-            },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              plugins: {
-                legend: {
-                  position: "bottom",
-                  labels: {
-                    boxWidth: 18,
-                    padding: 15,
-                    font: {
-                      size: 13
-                    }
-                  }
-                },
-                tooltip: {
-                  mode: "index",
-                  intersect: false
-                }
-              },
-              scales: {
-                y: {
-                  beginAtZero: true
-                }
-              }
-            }
-          });
-        } catch (err) {
-          console.error("Prediction chart error:", err);
-        }
-      }
-    });
-
-  </script>
+  <script src="/script_predict.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Implemented persistent chart filter saving and last activity tracking per user.
Updated user model to store lastFilters and lastActivity.
Modified home view to show recent Predict activity.
Adjusted Predict page script to auto-load saved filters on page load.