### PR TITLE
bugfix: recalculate affected values using sample_size and result; normalize group labels to fix '65+ years' issue

### DIFF
--- a/controllers/demographicsController.js
+++ b/controllers/demographicsController.js
@@ -15,7 +15,7 @@ const getDemographicsData = async (req, res) => {
       {
         $group: {
           _id: "$demographic_group",
-          total: { $sum: "$count" }
+          total: { $sum: "$affected" }
         }
       },
       { $sort: { total: -1 } }

--- a/controllers/foodSecurityController.js
+++ b/controllers/foodSecurityController.js
@@ -1,13 +1,13 @@
 const FoodSecurity = require("../models/FoodSecurity");
 
-// Pie Chart Data: Total count grouped by insecurity_type
+// Pie Chart Data: Total affected grouped by insecurity_type
 const getInsecurityTypeDistribution = async (req, res) => {
   try {
     const results = await FoodSecurity.aggregate([
       {
         $group: {
           _id: "$insecurity_type",
-          total: { $sum: "$count" }
+          total: { $sum: "$affected" }
         }
       },
       {
@@ -17,11 +17,11 @@ const getInsecurityTypeDistribution = async (req, res) => {
 
     // Transform for frontend (labels + values)
     const labels = results.map((item) => item._id);
-    const values = results.map((item) => item.total);
+    const values = results.map((item) => Math.round(item.total)); // Round for cleaner chart
 
     res.json({ labels, values });
   } catch (err) {
-    console.error(err.message);
+    console.error("Pie chart error:", err.message);
     res.status(500).json({ error: "Server Error" });
   }
 };

--- a/controllers/insightController.js
+++ b/controllers/insightController.js
@@ -1,6 +1,5 @@
 const FoodSecurity = require("../models/FoodSecurity");
 
-// Color palette for known insecurity types
 const colorMap = {
   "Accessed food relief services": "#42a5f5",
   "Insecurity (multiple concerns + relief)": "#66bb6a",
@@ -10,7 +9,6 @@ const colorMap = {
   "Worried food would run out": "#000000"
 };
 
-// Fallback color generator
 function getRandomColor() {
   const fallbackColors = [
     "#8d6e63", "#ffd54f", "#4db6ac",
@@ -19,20 +17,22 @@ function getRandomColor() {
   return fallbackColors[Math.floor(Math.random() * fallbackColors.length)];
 }
 
-// Controller for /api/insight
 const getInsightTrends = async (req, res) => {
   const { category, group } = req.query;
   if (!category || !group) {
     return res.status(400).json({ message: "Missing category or group" });
   }
 
+  // 🔧 Normalize group input
+  const normalizedGroup = group.trim().replace(/\s+/g, " ").replace(/(\d{2})\s*\+\s*years/, "$1+ years");
+
   try {
     const pipeline = [
-      { $match: { [category]: group } },
+      { $match: { [category]: normalizedGroup } },
       {
         $group: {
           _id: { year: "$year", insecurity_type: "$insecurity_type" },
-          total: { $sum: "$count" }
+          total: { $sum: "$affected" }
         }
       },
       { $sort: { "_id.year": 1 } }

--- a/controllers/trendsController.js
+++ b/controllers/trendsController.js
@@ -32,7 +32,7 @@ const getDistinctValues = async (req, res) => {
   try {
     let values = await FoodSecurity.distinct(category);
     values = values.filter(v => v !== null && v !== "null" && v !== undefined);
-    console.log(`📦 Distinct values for "${category}" →`, values.length);
+    console.log(`Distinct values for "${category}" →`, values.length);
     res.json({ values: values.sort() });
   } catch (err) {
     console.error("Error fetching distinct values:", err.message);
@@ -71,7 +71,7 @@ const getTrendData = async (req, res) => {
             year: "$year",
             value: `$${category}`
           },
-          total: { $sum: "$count" }
+          total: { $sum: "$affected" }
         }
       },
       {

--- a/models/FoodSecurity.js
+++ b/models/FoodSecurity.js
@@ -7,7 +7,11 @@ const foodSecuritySchema = new mongoose.Schema({
   demographic_group: String,
   gender: String,
   age_group: String,
-  suburb_group: String
+  sample_size: Number,
+  suburb_group: String,
+  result: Number,       
+  affected: Number      // calculated: (sample_size * result) / 100
+
 });
 
 module.exports = mongoose.model("FoodSecurity", foodSecuritySchema);

--- a/public/script_demographics.js
+++ b/public/script_demographics.js
@@ -41,35 +41,32 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   document.getElementById("resetButton").addEventListener("click", async () => {
-  // Reset dropdown to default (assumes "All" is default)
-  yearSelect.value = "All";
+  // Reset to "All"
+  const resetYear = "All";
+  yearSelect.value = resetYear;
   M.FormSelect.init(yearSelect);
 
-  // Destroy chart if visible
   if (chart) {
     chart.destroy();
     chart = null;
   }
 
-  // Clear saved filters from backend
+  // Clear filters and set default
   try {
     await fetch("/api/user/filters", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         chart: "demographics",
-        filters: {category: year}
+        filters: { category: resetYear }
       })
     });
   } catch (err) {
     console.error("Failed to reset filters:", err);
   }
 
-  // Scroll to top
   window.scrollTo(0, 0);
-
-  // Re-render chart for "All Years"
-  fetchDataAndRender();
+  fetchDataAndRender(); // Rerender with "All"
 });
 
   async function fetchDataAndRender() {

--- a/public/script_predict.js
+++ b/public/script_predict.js
@@ -70,8 +70,10 @@ document.addEventListener("DOMContentLoaded", function () {
       groupSelect.innerHTML = '<option value="" disabled selected>Select Group</option>';
       values.forEach(val => {
         const option = document.createElement("option");
-        option.value = val;
-        option.textContent = val;
+        
+        const normalizedVal = val.trim().replace(/\s+/g, " ").replace(/(\d{2})\s*\+\s*years/, "$1+ years");
+        option.value = normalizedVal;
+        option.textContent = normalizedVal;
 
         if (isInitialLoad && preselect === val) {
           option.selected = true;
@@ -117,7 +119,8 @@ function validateSelections() {
     if (!validateSelections()) return;
 
     const category = categorySelect.value;
-    const group = groupSelect.value;
+
+    const group = groupSelect.value?.trim().replace(/\s+/g, " ").replace(/(\d{2})\s*\+\s*years/, "$1+ years");
 
     document.body.style.cursor = "wait";
 
@@ -135,7 +138,7 @@ function validateSelections() {
     }
 
     try {
-      const res = await fetch(`/api/predict?category=${category}&group=${group}`);
+      const res = await fetch(`/api/predict?category=${category}&group=${encodeURIComponent(group)}`);
       const { years, actual, predicted, splitIndex } = await res.json();
 
       if (chart) chart.destroy();
@@ -185,6 +188,10 @@ function validateSelections() {
           },
           scales: {
             y: {
+              title: {
+                display: true,
+                text: "Estimated Affected Individuals"
+              },
               beginAtZero: true
             }
           }

--- a/public/script_type.js
+++ b/public/script_type.js
@@ -1,12 +1,13 @@
 document.addEventListener("DOMContentLoaded", () => {
   console.log("Script loaded!");
 
-  fetch("/api/type") 
+  fetch("/api/type")
     .then(res => res.json())
     .then(data => {
       console.log("Data fetched:", data.labels, data.values);
 
       const ctx = document.getElementById("pieChart").getContext("2d");
+
       new Chart(ctx, {
         type: "pie",
         data: {
@@ -20,16 +21,26 @@ document.addEventListener("DOMContentLoaded", () => {
           }]
         },
         options: {
+          responsive: true,
           plugins: {
+            tooltip: {
+              callbacks: {
+                label: (context) => {
+                  const label = context.label || "";
+                  const value = context.raw;
+                  return `${label}: ${value} cases`;
+                }
+              }
+            },
             legend: {
               position: 'bottom',
               labels: {
                 font: {
-                  size: 16 
+                  size: 16
                 },
                 padding: 12
               }
-            }
+            },
           }
         }
       });
@@ -38,13 +49,13 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Chart loading error:", err);
     });
 
-    fetch("/api/user/filters", {
+  // Save user view for analytics
+  fetch("/api/user/filters", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       chart: "type",
       filters: { viewed: true }
     })
-});
-
+  });
 });

--- a/views/combined_trends.ejs
+++ b/views/combined_trends.ejs
@@ -15,6 +15,9 @@
 <body class="container">
 
   <h5 class="center-align" style="margin-top: 2rem;">Combined Demographic Trends Over Time</h5>
+  <p class="center-align grey-text text-darken-2" style="margin-bottom: 2rem;">
+    This chart shows how food insecurity has affected different demographic groups over the years. Select a group to compare trends.
+  </p>
 
   <!-- Dropdown Selection -->
   <div class="row">

--- a/views/demographics.ejs
+++ b/views/demographics.ejs
@@ -29,6 +29,11 @@
     </div>
   </div>
 
+  <p class="grey-text text-darken-2" style="margin-bottom: 2rem;">
+    This chart displays the number of people affected by food insecurity, by various respondent groups. Select a year to explore changes over time.
+  </p>
+
+
   <!-- Chart -->
   <div class="chart-container">
     <canvas id="barChart"></canvas>

--- a/views/food_type.ejs
+++ b/views/food_type.ejs
@@ -7,9 +7,14 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="container center-align">
-  <h4>Food Insecurity Types Distribution</h4>
 
-  <div class="chart-container">
+  <h4 class="center-align" style="margin-top: 2rem;">Food Insecurity Types Distribution</h4>
+
+  <p class="grey-text text-darken-2" style="margin-bottom: 2rem;">
+    This chart shows the distribution of reported food insecurity types in Melbourne.
+  </p>
+
+  <div class="chart-container" style="max-width: 800px; margin: 0 auto;">
     <canvas id="pieChart"></canvas>
   </div>
 

--- a/views/insight.ejs
+++ b/views/insight.ejs
@@ -10,6 +10,10 @@
 <body class="container center-align">
 
   <h5>Food Insecurity Detailed Insight</h5>
+  <p class="center-align grey-text text-darken-2" style="margin-bottom: 2rem;">
+    This chart compares trends of different food insecurity types within a selected demographic group across the years. Choose a category and group to view detailed insights.
+  </p>
+
 
   <!-- Dropdowns -->
   <div class="row">

--- a/views/predict.ejs
+++ b/views/predict.ejs
@@ -10,6 +10,9 @@
 <body class="container center-align">
 
   <h5>Food Insecurity Prediction (2024–2026)</h5>
+  <p class="grey-text text-darken-2" style="margin-bottom: 2rem;">
+    This chart visualizes actual food insecurity data (2018–2023) for the selected group and forecasts future trends from 2024 to 2026 using regression-based modeling. The prediction helps identify potential increases or improvements in food insecurity within specific demographics.
+  </p>
 
   <!-- Dropdowns -->
   <div class="row">


### PR DESCRIPTION
This PR fixes the following issues:
- Recalculates `affected` using `sample_size * result / 100` during data seeding.
- Normalizes group labels (e.g., trims whitespace and fixes formatting like '65 + years' → '65+ years').
- Ensures charts (insight, predict, demographics, etc.) correctly display data for all groups.

Fixes the '65+ years' chart visibility issue and ensures consistency across all chart routes.